### PR TITLE
feature/add localization settings to AdaptiveApp

### DIFF
--- a/lib/src/adaptive_app.dart
+++ b/lib/src/adaptive_app.dart
@@ -39,7 +39,7 @@ class AdaptiveApp extends StatelessWidget {
     this.title,
     @required this.home,
     this.localizationsDelegates,
-    this.supportedLocales,
+    this.supportedLocales = const <Locale>[Locale('en', 'US')],
   })  : assert(home != null, 'AdaptiveApp: A home widget is required.'),
         super(key: key);
 

--- a/lib/src/adaptive_app.dart
+++ b/lib/src/adaptive_app.dart
@@ -21,14 +21,27 @@ class AdaptiveApp extends StatelessWidget {
   /// To specify theme data for a Cupertino app, use this field.
   final CupertinoThemeData cupertinoTheme;
 
+  /// The delegates for this app's [Localizations] widget.
+  ///
+  /// The delegates collectively define all of the localized resources for this application's [Localizations] widget.
+  final Iterable<LocalizationsDelegate<dynamic>> localizationsDelegates;
+
+  /// The list of locales that this app has been localized for.
+  ///
+  /// By default only the American English locale is supported. Apps should configure this list to match the locales they support.
+  final Iterable<Locale> supportedLocales;
+
   AdaptiveApp({
     Key key,
     this.materialTheme,
     this.cupertinoTheme,
     this.debugShowCheckedModeBanner = true,
     this.title,
-    this.home,
-  }) : super(key: key);
+    @required this.home,
+    this.localizationsDelegates,
+    this.supportedLocales,
+  })  : assert(home != null, 'AdaptiveApp: A home widget is required.'),
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -39,11 +52,15 @@ class AdaptiveApp extends StatelessWidget {
             theme: materialTheme,
             debugShowCheckedModeBanner: debugShowCheckedModeBanner,
             home: home,
+            localizationsDelegates: localizationsDelegates,
+            supportedLocales: supportedLocales,
           )
         : CupertinoApp(
             theme: cupertinoTheme,
             debugShowCheckedModeBanner: debugShowCheckedModeBanner,
             home: home,
+            localizationsDelegates: localizationsDelegates,
+            supportedLocales: supportedLocales,
           );
   }
 }


### PR DESCRIPTION
Thanks for creating this package! 

With regard to localizing apps, setting `localizationsDelegates` and `supportedLocales` properties of `MaterialApp` and `CupertinoApp` are needed, hence this small PR.

If localization is not required, both these properties can be ignored.

Also added `@required` annotation to `home` widget which is actually required for AdaptiveApp.